### PR TITLE
tests(streams) changing event-stream to stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "deep-diff": "^0.3.3",
-    "event-stream": "^3.3.2",
+    "stream-mock": "^2.0.3",
     "jshint": "^2.9.4",
     "proxyquire": "^1.7.10",
     "semantic-release": "^8.0.0",

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -1,13 +1,14 @@
 var tape = require( 'tape' );
-var event_stream = require( 'event-stream' );
 
 var CleanupStream = require( '../../lib/streams/cleanupStream' );
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'cleanupStream trims whitespace from all fields', function(test) {

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -1,15 +1,16 @@
 'use strict';
 
 const tape = require( 'tape' );
-const event_stream = require( 'event-stream' );
-
 const DocumentStream = require( '../../lib/streams/documentStream' );
 
-function test_stream(input, testedStream, callback) {
-  const input_stream = event_stream.readArray(input);
-  const destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-  input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'documentStream catches records with no street', function(test) {

--- a/test/streams/germanicAbbreviationStream.js
+++ b/test/streams/germanicAbbreviationStream.js
@@ -1,13 +1,15 @@
 var tape = require('tape');
-var event_stream = require( 'event-stream' );
 
 var germanicStream = require( '../../lib/streams/germanicAbbreviationStream' );
 
-function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-  input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'germanicStream expands tokens ending in "-str." to "-strasse" (mostly DEU)', function(test) {

--- a/test/streams/isUSorCAHouseNumberZero.js
+++ b/test/streams/isUSorCAHouseNumberZero.js
@@ -1,15 +1,16 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
 
 var isUSorCAHouseNumberZero = require('../../lib/streams/isUSorCAHouseNumberZero');
 
+const stream_mock = require('stream-mock');
+
 function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
-
-    input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
-
 tape('isUSorCAHouseNumberZero', function(t) {
   t.test('non-0 house number in USA should return true', function(t) {
     var records = [


### PR DESCRIPTION
Replacing event-stream with stream-mock as discussed in pelias/pelias#801
Edit: Dont merge!!! Tests are failling, but requires running ES cluster, I thought travis will run them, but will fix them myself